### PR TITLE
Fix code scanning alert no. 30: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx.Gtk3/Modules/Updater/Updater.cs
+++ b/src/Ryujinx.Gtk3/Modules/Updater/Updater.cs
@@ -405,9 +405,16 @@ namespace Ryujinx.Modules
                                 continue;
                             }
 
-                            string outPath = Path.Combine(_updateDir, tarEntry.Name);
+                            string entryName = tarEntry.Name;
+                            string outPath = Path.Combine(_updateDir, entryName);
+                            string fullPath = Path.GetFullPath(outPath);
 
-                            Directory.CreateDirectory(Path.GetDirectoryName(outPath));
+                            if (!fullPath.StartsWith(_updateDir))
+                            {
+                                throw new UnauthorizedAccessException("Invalid entry name in tar archive.");
+                            }
+
+                            Directory.CreateDirectory(Path.GetDirectoryName(fullPath));
 
                             using FileStream outStream = File.OpenWrite(outPath);
                             tarStream.CopyEntryContents(outStream);


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/30](https://github.com/ElProConLag/Ryujinx/security/code-scanning/30)

To fix the problem, we need to validate the `tarEntry.Name` before using it to construct the `outPath`. Specifically, we should ensure that the `tarEntry.Name` does not contain any path traversal sequences (e.g., "..") or absolute paths. We can achieve this by normalizing the path and checking that it remains within the intended directory.

1. Normalize the `tarEntry.Name` using `Path.GetFullPath` to resolve any relative components.
2. Ensure that the resulting path is still within the `_updateDir` by checking that it starts with `_updateDir`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
