### PR TITLE
Fix code scanning alert no. 193: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/src/Ryujinx.HLE/FileSystem/ContentManager.cs
+++ b/src/Ryujinx.HLE/FileSystem/ContentManager.cs
@@ -535,8 +535,12 @@ namespace Ryujinx.HLE.FileSystem
 
                     if (ncaId.Contains(".nca"))
                     {
-                        string newPath = Path.Combine(temporaryDirectory, ncaId);
-
+                        string newPath = Path.GetFullPath(Path.Combine(temporaryDirectory, ncaId));
+                        string fullDestDirPath = Path.GetFullPath(temporaryDirectory + Path.DirectorySeparatorChar);
+                        if (!newPath.StartsWith(fullDestDirPath))
+                        {
+                            throw new InvalidOperationException("Entry is outside the target dir: " + newPath);
+                        }
                         Directory.CreateDirectory(newPath);
 
                         entry.ExtractToFile(Path.Combine(newPath, "00"));


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/193](https://github.com/ElProConLag/Ryujinx/security/code-scanning/193)

To fix the problem, we need to ensure that the paths constructed from the zip archive entries are validated to prevent writing files to unexpected locations. The steps to fix this are:

1. Use `Path.GetFullPath` to resolve any directory traversal elements in the constructed path.
2. Use `Path.GetFullPath` on the destination directory to get its fully resolved path.
3. Validate that the resolved output path starts with the resolved destination directory path.
4. Throw an exception if the validation fails.

This ensures that the extracted files are written only within the intended directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
