### PR TITLE
Fix code scanning alert no. 180: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx.HLE/FileSystem/VirtualFileSystem.cs
+++ b/src/Ryujinx.HLE/FileSystem/VirtualFileSystem.cs
@@ -101,9 +101,10 @@ namespace Ryujinx.HLE.FileSystem
                 return null;
             }
 
-            string fullPath = Path.GetFullPath(Path.Combine(basePath, fileName));
+            string combinedPath = Path.Combine(basePath, fileName);
+            string fullPath = Path.GetFullPath(combinedPath);
 
-            if (!fullPath.StartsWith(AppDataManager.BaseDirPath))
+            if (!fullPath.StartsWith(Path.GetFullPath(AppDataManager.BaseDirPath) + Path.DirectorySeparatorChar))
             {
                 return null;
             }


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/180](https://github.com/ElProConLag/Ryujinx/security/code-scanning/180)

To fix the problem, we need to ensure that the path constructed from user-controlled data is properly validated to prevent directory traversal attacks. This can be achieved by:
1. Normalizing the path to remove any redundant or dangerous components.
2. Ensuring that the resulting path is within a specific allowed directory.

We will modify the `GetFullPath` method in `VirtualFileSystem.cs` to include additional validation checks. Specifically, we will:
- Normalize the path using `Path.GetFullPath`.
- Ensure that the normalized path is within the allowed base directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
