### PR TITLE
Fix code scanning alert no. 23: Uncontrolled command line

### DIFF
--- a/src/Ryujinx.UI.Common/Helper/FileAssociationHelper.cs
+++ b/src/Ryujinx.UI.Common/Helper/FileAssociationHelper.cs
@@ -14,7 +14,7 @@ namespace Ryujinx.UI.Common.Helper
         private static readonly string[] _fileExtensions = { ".nca", ".nro", ".nso", ".nsp", ".xci" };
 
         [SupportedOSPlatform("linux")]
-        private static readonly string _mimeDbPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local", "share", "mime");
+        private static readonly string _mimeDbPath = ValidateMimeDbPath(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local", "share", "mime"));
 
         private const int SHCNE_ASSOCCHANGED = 0x8000000;
         private const int SHCNF_FLUSH = 0x1000;
@@ -67,6 +67,16 @@ namespace Ryujinx.UI.Common.Helper
             }
 
             return true;
+        }
+
+        private static string ValidateMimeDbPath(string path)
+        {
+            string userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            if (!path.StartsWith(userProfile) || path.Contains(";") || path.Contains("&") || path.Contains("|"))
+            {
+                throw new InvalidOperationException("Invalid mime database path.");
+            }
+            return path;
         }
 
         [SupportedOSPlatform("windows")]


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/23](https://github.com/ElProConLag/Ryujinx/security/code-scanning/23)

To fix the problem, we need to ensure that the `_mimeDbPath` is sanitized or validated before being used in the command line. One way to do this is to check that the path is within a known safe directory and does not contain any unexpected characters or sequences that could lead to command injection.

We can implement a validation function that ensures `_mimeDbPath` is within the user's home directory and does not contain any suspicious characters. This function will be called before using `_mimeDbPath` in the `Process.Start` method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
