### PR TITLE
Fix code scanning alert no. 178: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx.HLE/HOS/Services/Nfc/Nfp/VirtualAmiibo.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Nfc/Nfp/VirtualAmiibo.cs
@@ -165,9 +165,16 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
 
         private static VirtualAmiiboFile LoadAmiiboFile(string amiiboId)
         {
-            Directory.CreateDirectory(Path.Join(AppDataManager.BaseDirPath, "system", "amiibo"));
+            string amiiboDir = Path.GetFullPath(Path.Join(AppDataManager.BaseDirPath, "system", "amiibo"));
 
-            string filePath = Path.Join(AppDataManager.BaseDirPath, "system", "amiibo", $"{amiiboId}.json");
+            if (!amiiboDir.StartsWith(Path.GetFullPath(AppDataManager.BaseDirPath)))
+            {
+                throw new UnauthorizedAccessException("Invalid path");
+            }
+
+            Directory.CreateDirectory(amiiboDir);
+
+            string filePath = Path.Join(amiiboDir, $"{amiiboId}.json");
 
             VirtualAmiiboFile virtualAmiiboFile;
 
@@ -196,7 +203,14 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
 
         private static void SaveAmiiboFile(VirtualAmiiboFile virtualAmiiboFile)
         {
-            string filePath = Path.Join(AppDataManager.BaseDirPath, "system", "amiibo", $"{virtualAmiiboFile.AmiiboId}.json");
+            string amiiboDir = Path.GetFullPath(Path.Join(AppDataManager.BaseDirPath, "system", "amiibo"));
+
+            if (!amiiboDir.StartsWith(Path.GetFullPath(AppDataManager.BaseDirPath)))
+            {
+                throw new UnauthorizedAccessException("Invalid path");
+            }
+
+            string filePath = Path.Join(amiiboDir, $"{virtualAmiiboFile.AmiiboId}.json");
             JsonHelper.SerializeToFile(filePath, virtualAmiiboFile, _serializerContext.VirtualAmiiboFile);
         }
     }


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/178](https://github.com/ElProConLag/Ryujinx/security/code-scanning/178)

To fix the problem, we need to ensure that the paths constructed using `AppDataManager.BaseDirPath` are validated to prevent directory traversal attacks. This can be achieved by checking that the resolved path is within a specific safe directory.

1. Normalize the constructed path using `Path.GetFullPath`.
2. Ensure that the normalized path starts with the expected base directory path.
3. If the path is invalid, handle the error appropriately (e.g., log the error, throw an exception, or return an error response).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
