### PR TITLE
Fix code scanning alert no. 185: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx.HLE/Loaders/Processes/ProcessLoader.cs
+++ b/src/Ryujinx.HLE/Loaders/Processes/ProcessLoader.cs
@@ -34,7 +34,16 @@ namespace Ryujinx.HLE.Loaders.Processes
 
         public bool LoadXci(string path, ulong applicationId)
         {
-            FileStream stream = new(path, FileMode.Open, FileAccess.Read);
+            string baseDirectory = AppDataManager.BaseDirPath; // Define a safe base directory
+            string fullPath = Path.GetFullPath(path);
+
+            if (!fullPath.StartsWith(baseDirectory + Path.DirectorySeparatorChar))
+            {
+                Logger.Error?.Print(LogClass.Loader, "Invalid path: Access outside of the base directory is not allowed.");
+                return false;
+            }
+
+            FileStream stream = new(fullPath, FileMode.Open, FileAccess.Read);
             Xci xci = new(_device.Configuration.VirtualFileSystem.KeySet, stream.AsStorage());
 
             if (!xci.HasPartition(XciPartitionType.Secure))


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/185](https://github.com/ElProConLag/Ryujinx/security/code-scanning/185)

To fix the problem, we need to validate the `path` parameter before using it to open a file stream. The validation should ensure that the path is within a specific directory and does not contain any path traversal sequences. We can achieve this by checking that the resolved path is still contained within a safe base directory.

1. Define a base directory that is considered safe.
2. Resolve the full path of the user-provided `path`.
3. Check that the resolved path starts with the base directory path.
4. If the validation fails, log an error and return `false`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
