### PR TITLE
Fix code scanning alert no. 176: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx.HLE/FileSystem/VirtualFileSystem.cs
+++ b/src/Ryujinx.HLE/FileSystem/VirtualFileSystem.cs
@@ -104,6 +104,9 @@ namespace Ryujinx.HLE.FileSystem
             string combinedPath = Path.Combine(basePath, fileName);
             string fullPath = Path.GetFullPath(combinedPath);
 
+            // Normalize the path to remove any redundant components
+            fullPath = Path.GetFullPath(new Uri(fullPath).LocalPath);
+
             if (!fullPath.StartsWith(Path.GetFullPath(AppDataManager.BaseDirPath) + Path.DirectorySeparatorChar))
             {
                 return null;

--- a/src/Ryujinx.HLE/HOS/Services/Fs/IFileSystemProxy.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Fs/IFileSystemProxy.cs
@@ -54,7 +54,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             string switchPath = ReadUtf8String(context);
             string fullPath = FileSystem.VirtualFileSystem.SwitchPathToSystemPath(switchPath);
 
-            if (!File.Exists(fullPath))
+            if (fullPath == null || !File.Exists(fullPath))
             {
                 if (fullPath.Contains('.'))
                 {


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/176](https://github.com/ElProConLag/Ryujinx/security/code-scanning/176)

To fix the problem, we need to ensure that the user-provided path is properly sanitized and validated before being used in file operations. Specifically, we should:
1. Normalize the path to remove any redundant or potentially malicious components.
2. Ensure that the resulting path is within a specific allowed directory.
3. Reject any input that contains path traversal sequences or attempts to access files outside the allowed directory.

We will modify the `SwitchPathToSystemPath` and `GetFullPath` methods to include these checks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
