### PR TITLE
Fix code scanning alert no. 192: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx.UI.Common/Helper/ShortcutHelper.cs
+++ b/src/Ryujinx.UI.Common/Helper/ShortcutHelper.cs
@@ -151,6 +151,12 @@ namespace Ryujinx.UI.Common.Helper
         [SupportedOSPlatform("windows")]
         private static void SaveBitmapAsIcon(SKBitmap source, string filePath)
         {
+            // Validate the file path
+            if (!IsValidFilePath(filePath))
+            {
+                throw new ArgumentException("Invalid file path.");
+            }
+
             // Code Modified From https://stackoverflow.com/a/11448060/368354 by Benlitz
             byte[] header = { 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1, 0, 32, 0, 0, 0, 0, 0, 22, 0, 0, 0 };
             using FileStream fs = new(filePath, FileMode.Create);
@@ -167,6 +173,13 @@ namespace Ryujinx.UI.Common.Helper
             fs.WriteByte((byte)(dataLength >> 8));
             fs.WriteByte((byte)(dataLength >> 16));
             fs.WriteByte((byte)(dataLength >> 24));
+        }
+
+        private static bool IsValidFilePath(string filePath)
+        {
+            string baseDirPath = AppDataManager.BaseDirPath;
+            string fullPath = Path.GetFullPath(filePath);
+            return fullPath.StartsWith(baseDirPath + Path.DirectorySeparatorChar);
         }
     }
 }


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/192](https://github.com/ElProConLag/Ryujinx/security/code-scanning/192)

To fix the problem, we need to validate the `filePath` before using it in the `FileStream` constructor. We should ensure that the `filePath` is within a specific directory and does not contain any path traversal sequences. This can be done by checking that the resolved path is still contained within the intended base directory.

1. Add a method to validate the `filePath` to ensure it is within the `BaseDirPath`.
2. Use this validation method before creating the `FileStream` in the `SaveBitmapAsIcon` method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
