### PR TITLE
Fix code scanning alert no. 197: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx.HLE/FileSystem/VirtualFileSystem.cs
+++ b/src/Ryujinx.HLE/FileSystem/VirtualFileSystem.cs
@@ -184,7 +184,13 @@ namespace Ryujinx.HLE.FileSystem
                     break;
             }
 
-            string fullPath = Path.Combine(AppDataManager.BaseDirPath, path);
+            string fullPath = Path.GetFullPath(Path.Combine(AppDataManager.BaseDirPath, path));
+
+            // Ensure the fullPath is within the BaseDirPath
+            if (!fullPath.StartsWith(AppDataManager.BaseDirPath + Path.DirectorySeparatorChar))
+            {
+                throw new ArgumentException("Invalid path: Path traversal detected");
+            }
 
             if (isDirectory && !Directory.Exists(fullPath))
             {


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/197](https://github.com/ElProConLag/Ryujinx/security/code-scanning/197)

To fix the problem, we need to ensure that the constructed `fullPath` is contained within a safe directory and does not allow directory traversal. We can achieve this by validating the resolved path to ensure it remains within the intended base directory.

1. Modify the `MakeFullPath` method to validate the `fullPath` after it is constructed.
2. Ensure that the `fullPath` starts with the `BaseDirPath` to prevent directory traversal.
3. Update the `IsValidPath` method to include additional checks if necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
