### PR TITLE
Fix code scanning alert no. 173: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx.HLE/HOS/ModLoader.cs
+++ b/src/Ryujinx.HLE/HOS/ModLoader.cs
@@ -263,9 +263,17 @@ namespace Ryujinx.HLE.HOS
             }
 
             string modJsonPath = Path.Combine(AppDataManager.GamesDirPath, applicationId.ToString("x16"), "mods.json");
+            string fullModJsonPath = Path.GetFullPath(modJsonPath);
+
+            if (!fullModJsonPath.StartsWith(Path.GetFullPath(AppDataManager.GamesDirPath) + Path.DirectorySeparatorChar))
+            {
+                Logger.Warning?.Print(LogClass.ModLoader, $"Invalid mod path: {fullModJsonPath}");
+                return;
+            }
+
             ModMetadata modMetadata = new();
 
-            if (File.Exists(modJsonPath))
+            if (File.Exists(fullModJsonPath))
             {
                 try
                 {


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/173](https://github.com/ElProConLag/Ryujinx/security/code-scanning/173)

To fix the problem, we need to ensure that the constructed path remains within a safe directory. This can be achieved by validating the resolved path to ensure it is contained within the expected base directory. We will use `Path.GetFullPath` to resolve the absolute path and then check if it starts with the expected base directory path.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
