### PR TITLE
Fix code scanning alert no. 179: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx.HLE/HOS/Services/Nfc/Nfp/VirtualAmiibo.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Nfc/Nfp/VirtualAmiibo.cs
@@ -165,6 +165,11 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
 
         private static VirtualAmiiboFile LoadAmiiboFile(string amiiboId)
         {
+            if (amiiboId.Contains("..") || amiiboId.Contains("/") || amiiboId.Contains("\\"))
+            {
+                throw new ArgumentException("Invalid amiiboId");
+            }
+
             string amiiboDir = Path.GetFullPath(Path.Join(AppDataManager.BaseDirPath, "system", "amiibo"));
 
             if (!amiiboDir.StartsWith(Path.GetFullPath(AppDataManager.BaseDirPath)))
@@ -203,6 +208,11 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
 
         private static void SaveAmiiboFile(VirtualAmiiboFile virtualAmiiboFile)
         {
+            if (virtualAmiiboFile.AmiiboId.Contains("..") || virtualAmiiboFile.AmiiboId.Contains("/") || virtualAmiiboFile.AmiiboId.Contains("\\"))
+            {
+                throw new ArgumentException("Invalid amiiboId");
+            }
+
             string amiiboDir = Path.GetFullPath(Path.Join(AppDataManager.BaseDirPath, "system", "amiibo"));
 
             if (!amiiboDir.StartsWith(Path.GetFullPath(AppDataManager.BaseDirPath)))


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/179](https://github.com/ElProConLag/Ryujinx/security/code-scanning/179)

To fix the problem, we need to validate the `amiiboId` to ensure it does not contain any path traversal characters or path separators. This can be done by checking for the presence of `..`, `/`, or `\` in the `amiiboId`. If any of these characters are found, we should throw an exception or handle the error appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
