### PR TITLE
Fix code scanning alert no. 124: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx.Common/Configuration/AppDataManager.cs
+++ b/src/Ryujinx.Common/Configuration/AppDataManager.cs
@@ -83,14 +83,26 @@ namespace Ryujinx.Common.Configuration
 
             if (baseDirPath != null && baseDirPath != userProfilePath)
             {
-                if (!Directory.Exists(baseDirPath))
+                if (baseDirPath.Contains("..") || baseDirPath.Contains("/") || baseDirPath.Contains("\\"))
+                {
+                    Logger.Error?.Print(LogClass.Application, $"Invalid custom data directory '{baseDirPath}'. Falling back to {Mode}...");
+                }
+                else if (!Directory.Exists(baseDirPath))
                 {
                     Logger.Error?.Print(LogClass.Application, $"Custom Data Directory '{baseDirPath}' does not exist. Falling back to {Mode}...");
                 }
                 else
                 {
-                    BaseDirPath = baseDirPath;
-                    Mode = LaunchMode.Custom;
+                    string fullPath = Path.GetFullPath(baseDirPath);
+                    if (!fullPath.StartsWith(Path.GetFullPath(userProfilePath) + Path.DirectorySeparatorChar))
+                    {
+                        Logger.Error?.Print(LogClass.Application, $"Custom Data Directory '{baseDirPath}' is outside the allowed directory. Falling back to {Mode}...");
+                    }
+                    else
+                    {
+                        BaseDirPath = fullPath;
+                        Mode = LaunchMode.Custom;
+                    }
                 }
             }
 


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/124](https://github.com/ElProConLag/Ryujinx/security/code-scanning/124)

To fix the problem, we need to validate the `baseDirPath` to ensure it does not contain any path separators or parent directory references. Additionally, we should ensure that the resolved path is contained within a safe directory. This can be achieved by:
1. Checking that `baseDirPath` does not contain "..", "/", or "\\".
2. Ensuring that the resolved `BaseDirPath` is within a predefined safe directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
