### PR TITLE
Fix code scanning alert no. 198: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx.HLE/HOS/ModLoader.cs
+++ b/src/Ryujinx.HLE/HOS/ModLoader.cs
@@ -265,7 +265,9 @@ namespace Ryujinx.HLE.HOS
             string modJsonPath = Path.Combine(AppDataManager.GamesDirPath, applicationId.ToString("x16"), "mods.json");
             string fullModJsonPath = Path.GetFullPath(modJsonPath);
 
-            if (!fullModJsonPath.StartsWith(Path.GetFullPath(AppDataManager.GamesDirPath) + Path.DirectorySeparatorChar))
+            // Ensure the path is within the expected base directory and does not contain path traversal sequences
+            if (!fullModJsonPath.StartsWith(Path.GetFullPath(AppDataManager.GamesDirPath) + Path.DirectorySeparatorChar) ||
+                fullModJsonPath.Contains("..") || fullModJsonPath.Contains(Path.DirectorySeparatorChar + ".") || fullModJsonPath.Contains("." + Path.DirectorySeparatorChar))
             {
                 Logger.Warning?.Print(LogClass.ModLoader, $"Invalid mod path: {fullModJsonPath}");
                 return;


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/198](https://github.com/ElProConLag/Ryujinx/security/code-scanning/198)

To fix the problem, we need to ensure that the path constructed from user-controllable data is properly validated. This involves checking that the path is within a specific directory and does not contain any path traversal sequences.

1. **Normalize the path**: Convert the path to its absolute form to eliminate any relative path components.
2. **Validate the path**: Ensure that the normalized path is within the expected base directory and does not contain any path traversal sequences.

We will implement these changes in the `QueryApplicationDir` method in `src/Ryujinx.HLE/HOS/ModLoader.cs`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
