### PR TITLE
Fix code scanning alert no. 196: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx.HLE/Loaders/Processes/ProcessLoader.cs
+++ b/src/Ryujinx.HLE/Loaders/Processes/ProcessLoader.cs
@@ -34,6 +34,13 @@ namespace Ryujinx.HLE.Loaders.Processes
 
         public bool LoadXci(string path, ulong applicationId)
         {
+            // Validate the path to prevent directory traversal
+            if (path.Contains("..") || path.Contains("/") || path.Contains("\\"))
+            {
+                Logger.Error?.Print(LogClass.Loader, "Invalid path: Path traversal detected.");
+                return false;
+            }
+
             string baseDirectory = AppDataManager.BaseDirPath; // Define a safe base directory
             string fullPath = Path.GetFullPath(path);
 


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/196](https://github.com/ElProConLag/Ryujinx/security/code-scanning/196)

To fix the problem, we need to add validation to the `path` parameter to ensure it does not contain any invalid characters or sequences that could lead to directory traversal attacks. Specifically, we should check for the presence of "..", "/", and "\\" in the `path` parameter and reject the input if any are found.

1. Add a validation check for the `path` parameter to ensure it does not contain any invalid characters or sequences.
2. Update the `LoadXci` method in the `ProcessLoader` class to include this validation.
3. If the validation fails, log an error message and return `false`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
