### PR TITLE
Fix code scanning alert no. 186: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx.HLE/Loaders/Processes/ProcessLoader.cs
+++ b/src/Ryujinx.HLE/Loaders/Processes/ProcessLoader.cs
@@ -84,7 +84,23 @@ namespace Ryujinx.HLE.Loaders.Processes
 
         public bool LoadNsp(string path, ulong applicationId)
         {
-            FileStream file = new(path, FileMode.Open, FileAccess.Read);
+            // Validate the path to prevent directory traversal
+            if (path.Contains("..") || path.Contains("/") || path.Contains("\\"))
+            {
+                Logger.Error?.Print(LogClass.Loader, "Invalid path: Path traversal detected.");
+                return false;
+            }
+
+            string baseDirectory = AppDataManager.BaseDirPath; // Define a safe base directory
+            string fullPath = Path.GetFullPath(path);
+
+            if (!fullPath.StartsWith(baseDirectory + Path.DirectorySeparatorChar))
+            {
+                Logger.Error?.Print(LogClass.Loader, "Invalid path: Access outside of the base directory is not allowed.");
+                return false;
+            }
+
+            FileStream file = new(fullPath, FileMode.Open, FileAccess.Read);
             PartitionFileSystem partitionFileSystem = new();
             partitionFileSystem.Initialize(file.AsStorage()).ThrowIfFailure();
 


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/186](https://github.com/ElProConLag/Ryujinx/security/code-scanning/186)

To fix the problem, we need to validate the `path` parameter in the `LoadNsp` method to ensure it does not contain any directory traversal sequences or absolute paths. This can be done by checking for the presence of `..`, `/`, or `\` in the `path` and ensuring that the resolved path is within a safe base directory.

1. Add validation logic to the `LoadNsp` method similar to the `LoadXci` method.
2. Ensure that the `path` is resolved to an absolute path and checked against a base directory to prevent directory traversal.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
