### PR TITLE
Fix code scanning alert no. 77: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx/Modules/Updater/Updater.cs
+++ b/src/Ryujinx/Modules/Updater/Updater.cs
@@ -523,10 +523,16 @@ namespace Ryujinx.Modules
                 }
 
                 string outPath = Path.Combine(outputDirectoryPath, tarEntry.Name);
+                string fullPath = Path.GetFullPath(outPath);
 
-                Directory.CreateDirectory(Path.GetDirectoryName(outPath));
+                if (!fullPath.StartsWith(Path.GetFullPath(outputDirectoryPath)))
+                {
+                    throw new UnauthorizedAccessException("Attempt to write outside of the target directory.");
+                }
 
-                using FileStream outStream = File.OpenWrite(outPath);
+                Directory.CreateDirectory(Path.GetDirectoryName(fullPath));
+
+                using FileStream outStream = File.OpenWrite(fullPath);
                 tarStream.CopyEntryContents(outStream);
 
                 File.SetUnixFileMode(outPath, (UnixFileMode)tarEntry.TarHeader.Mode);
@@ -559,11 +565,17 @@ namespace Ryujinx.Modules
                 }
 
                 string outPath = Path.Combine(outputDirectoryPath, zipEntry.Name);
+                string fullPath = Path.GetFullPath(outPath);
 
-                Directory.CreateDirectory(Path.GetDirectoryName(outPath));
+                if (!fullPath.StartsWith(Path.GetFullPath(outputDirectoryPath)))
+                {
+                    throw new UnauthorizedAccessException("Attempt to write outside of the target directory.");
+                }
+
+                Directory.CreateDirectory(Path.GetDirectoryName(fullPath));
 
                 using Stream zipStream = zipFile.GetInputStream(zipEntry);
-                using FileStream outStream = File.OpenWrite(outPath);
+                using FileStream outStream = File.OpenWrite(fullPath);
 
                 zipStream.CopyTo(outStream);
 


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/77](https://github.com/ElProConLag/Ryujinx/security/code-scanning/77)

To fix the problem, we need to validate the paths constructed from user-controlled input to ensure they do not contain any directory traversal sequences or invalid characters. Specifically, we should:
1. Normalize the paths to remove any redundant or malicious sequences.
2. Ensure the paths are within the intended directory by checking the resolved paths against the base directory.

We will implement these changes in the `ExtractTarGzipFile` and `ExtractZipFile` methods to validate the `outPath` before creating directories or writing files.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
