### PR TITLE
Fix code scanning alert no. 167: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx.HLE/FileSystem/ContentManager.cs
+++ b/src/Ryujinx.HLE/FileSystem/ContentManager.cs
@@ -115,6 +115,12 @@ namespace Ryujinx.HLE.FileSystem
                     }
                     var registeredDirectory = Path.Combine(contentDirectory, "registered");
 
+                    if (!IsValidPath(registeredDirectory, contentDirectory))
+                    {
+                        Logger.Warning?.Print(LogClass.Application, $"Invalid path detected: {registeredDirectory}");
+                        continue;
+                    }
+
                     Directory.CreateDirectory(registeredDirectory);
 
                     LinkedList<LocationEntry> locationList = new();
@@ -968,4 +974,10 @@ namespace Ryujinx.HLE.FileSystem
             return null;
         }
     }
-}
+                private bool IsValidPath(string path, string baseDirectory)
+                {
+                    string fullPath = Path.GetFullPath(path);
+                    return fullPath.StartsWith(baseDirectory + Path.DirectorySeparatorChar) &&
+                           !path.Contains("..") && !path.Contains("/") && !path.Contains("\\");
+                }
+            }


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/167](https://github.com/ElProConLag/Ryujinx/security/code-scanning/167)

To fix the problem, we need to ensure that the `registeredDirectory` path is validated before it is used. This involves checking that the path does not contain any invalid components (like "..", "/", or "\\") and ensuring that it is within a safe directory.

1. Add a method to validate the path.
2. Use this method to validate `registeredDirectory` before using it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
