### PR TITLE
Fix code scanning alert no. 201: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx/Modules/Updater/Updater.cs
+++ b/src/Ryujinx/Modules/Updater/Updater.cs
@@ -42,6 +42,14 @@ namespace Ryujinx.Modules
         private static string _buildVer;
         private static string _platformExt;
         private static string _buildUrl;
+
+        private static void ValidatePath(string path)
+        {
+            if (path.Contains("..") || path.Contains("/") || path.Contains("\\"))
+            {
+                throw new UnauthorizedAccessException("Invalid path.");
+            }
+        }
         private static long _buildSize;
         private static bool _updateSuccessful;
         private static bool _running;
@@ -509,6 +517,8 @@ namespace Ryujinx.Modules
         [SupportedOSPlatform("macos")]
         private static void ExtractTarGzipFile(TaskDialog taskDialog, string archivePath, string outputDirectoryPath)
         {
+            ValidatePath(outputDirectoryPath);
+
             using Stream inStream = File.OpenRead(archivePath);
             using GZipInputStream gzipStream = new(inStream);
             using TarInputStream tarStream = new(gzipStream, Encoding.ASCII);
@@ -552,6 +562,8 @@ namespace Ryujinx.Modules
 
         private static void ExtractZipFile(TaskDialog taskDialog, string archivePath, string outputDirectoryPath)
         {
+            ValidatePath(outputDirectoryPath);
+
             using Stream inStream = File.OpenRead(archivePath);
             using ZipFile zipFile = new(inStream);
 


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/201](https://github.com/ElProConLag/Ryujinx/security/code-scanning/201)

To fix the problem, we need to ensure that the paths constructed using `Path.GetTempPath()` are validated to prevent directory traversal attacks. Specifically, we should validate that the `outputDirectoryPath` and the paths derived from it do not contain any unexpected special characters or sequences that could lead to directory traversal.

1. Add a method to validate the paths to ensure they do not contain any ".." sequences or path separators.
2. Use this validation method to check the `outputDirectoryPath` before using it to construct other paths.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
