### PR TITLE
Fix code scanning alert no. 165: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx.HLE/FileSystem/VirtualFileSystem.cs
+++ b/src/Ryujinx.HLE/FileSystem/VirtualFileSystem.cs
@@ -187,7 +187,7 @@ namespace Ryujinx.HLE.FileSystem
             string fullPath = Path.GetFullPath(Path.Combine(AppDataManager.BaseDirPath, path));
 
             // Ensure the fullPath is within the BaseDirPath
-            if (!fullPath.StartsWith(AppDataManager.BaseDirPath + Path.DirectorySeparatorChar))
+            if (!IsValidFullPath(fullPath, AppDataManager.BaseDirPath))
             {
                 throw new ArgumentException("Invalid path: Path traversal detected");
             }
@@ -209,6 +209,15 @@ namespace Ryujinx.HLE.FileSystem
             }
 
             return true;
+        }
+
+        private static bool IsValidFullPath(string fullPath, string baseDirPath)
+        {
+            // Normalize the base directory path
+            string normalizedBaseDirPath = Path.GetFullPath(baseDirPath);
+
+            // Ensure the fullPath is within the BaseDirPath
+            return fullPath.StartsWith(normalizedBaseDirPath + Path.DirectorySeparatorChar);
         }
 
         public void InitializeFsServer(LibHac.Horizon horizon, out HorizonClient fsServerClient)


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/165](https://github.com/ElProConLag/Ryujinx/security/code-scanning/165)

To fix the problem, we need to enhance the validation of the `fullPath` to ensure it does not allow directory traversal. This can be achieved by normalizing the path and ensuring it remains within the intended base directory. We will use `Path.GetFullPath` to normalize the path and then check if it starts with the base directory path.

1. Enhance the `IsValidPath` method to include normalization and containment checks.
2. Ensure that the `fullPath` is validated after combining it with `AppDataManager.BaseDirPath`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
