### PR TITLE
Fix code scanning alert no. 100: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx.Common/Utilities/JsonHelper.cs
+++ b/src/Ryujinx.Common/Utilities/JsonHelper.cs
@@ -49,8 +49,23 @@ namespace Ryujinx.Common.Utilities
 
         public static T DeserializeFromFile<T>(string filePath, JsonTypeInfo<T> typeInfo)
         {
+            if (!IsValidPath(filePath))
+            {
+                throw new ArgumentException("Invalid file path.");
+            }
             using FileStream file = File.OpenRead(filePath);
             return JsonSerializer.Deserialize(file, typeInfo);
+        }
+
+        private static bool IsValidPath(string filePath)
+        {
+            string baseDir = AppDataManager.GamesDirPath;
+            string fullPath = Path.GetFullPath(filePath);
+
+            return fullPath.StartsWith(baseDir + Path.DirectorySeparatorChar) &&
+                   !fullPath.Contains("..") &&
+                   !fullPath.Contains(Path.DirectorySeparatorChar + ".") &&
+                   !fullPath.Contains("." + Path.DirectorySeparatorChar);
         }
 
         public static void SerializeToStream<T>(Stream stream, T value, JsonTypeInfo<T> typeInfo)


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/100](https://github.com/ElProConLag/Ryujinx/security/code-scanning/100)

To fix the problem, we need to validate the `filePath` before using it in file operations. Specifically, we should ensure that the `filePath` is within a predefined safe directory and does not contain any path traversal sequences. This can be achieved by checking that the resolved path starts with the expected base directory and does not contain any ".." sequences.

1. Add a method to validate the file path.
2. Use this method in the `DeserializeFromFile` method to ensure the path is safe before proceeding with file operations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
