### PR TITLE
Fix code scanning alert no. 159: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx.Gtk3/UI/Windows/ControllerWindow.cs
+++ b/src/Ryujinx.Gtk3/UI/Windows/ControllerWindow.cs
@@ -779,6 +779,12 @@ namespace Ryujinx.UI.Windows
             return AppDataManager.ProfilesDirPath;
         }
 
+        private bool IsPathValid(string path, string basePath)
+        {
+            string fullPath = Path.GetFullPath(path);
+            return fullPath.StartsWith(basePath + Path.DirectorySeparatorChar);
+        }
+
         //
         // Events
         //
@@ -1154,6 +1160,11 @@ namespace Ryujinx.UI.Windows
             if (profileDialog.Run() == (int)ResponseType.Ok)
             {
                 string path = System.IO.Path.Combine(GetProfileBasePath(), profileDialog.FileName);
+                if (!IsPathValid(path, GetProfileBasePath()))
+                {
+                    // Handle invalid path scenario
+                    return;
+                }
                 string jsonString = JsonHelper.Serialize(inputConfig, _serializerContext.InputConfig);
 
                 File.WriteAllText(path, jsonString);
@@ -1178,7 +1189,11 @@ namespace Ryujinx.UI.Windows
             if (confirmDialog.Run() == (int)ResponseType.Yes)
             {
                 string path = System.IO.Path.Combine(GetProfileBasePath(), _profile.ActiveId);
-
+                if (!IsPathValid(path, GetProfileBasePath()))
+                {
+                    // Handle invalid path scenario
+                    return;
+                }
                 if (File.Exists(path))
                 {
                     File.Delete(path);


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/159](https://github.com/ElProConLag/Ryujinx/security/code-scanning/159)

To fix the problem, we need to ensure that the constructed file paths are validated to prevent path traversal attacks. This can be achieved by checking that the resolved path is within the expected base directory. We will implement a method to validate the paths and use it before performing file operations.

1. Add a method to validate that the constructed path is within the `ProfilesDirPath`.
2. Use this validation method before performing file operations like `File.Delete`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
