### PR TITLE
Fix code scanning alert no. 162: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx.Gtk3/UI/Windows/AmiiboWindow.cs
+++ b/src/Ryujinx.Gtk3/UI/Windows/AmiiboWindow.cs
@@ -61,9 +61,19 @@ namespace Ryujinx.UI.Windows
                 Timeout = TimeSpan.FromSeconds(30),
             };
 
-            Directory.CreateDirectory(System.IO.Path.Join(AppDataManager.BaseDirPath, "system", "amiibo"));
+            string amiiboDir = System.IO.Path.Join(AppDataManager.BaseDirPath, "system", "amiibo");
+            Directory.CreateDirectory(amiiboDir);
 
-            _amiiboJsonPath = System.IO.Path.Join(AppDataManager.BaseDirPath, "system", "amiibo", "Amiibo.json");
+            _amiiboJsonPath = System.IO.Path.Join(amiiboDir, "Amiibo.json");
+
+            // Validate the constructed path
+            string fullPath = Path.GetFullPath(_amiiboJsonPath);
+            if (!fullPath.StartsWith(amiiboDir + Path.DirectorySeparatorChar))
+            {
+                Logger.Error?.Print(LogClass.Application, $"Invalid path detected: {_amiiboJsonPath}");
+                throw new InvalidOperationException("Invalid path detected.");
+            }
+
             _amiiboList = new List<AmiiboApi>();
 
             _amiiboLogoBytes = EmbeddedResources.Read("Ryujinx.UI.Common/Resources/Logo_Amiibo.png");


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/162](https://github.com/ElProConLag/Ryujinx/security/code-scanning/162)

To fix the problem, we need to ensure that the constructed path `_amiiboJsonPath` is validated to prevent directory traversal attacks. This can be done by checking that the resolved path is contained within a specific directory, ensuring it does not contain any unexpected special characters or sequences like "..".

1. Validate the `_amiiboJsonPath` to ensure it is within the expected directory.
2. Use `Path.GetFullPath` to resolve the absolute path and check that it starts with the base directory path.
3. If the validation fails, log an error and handle the situation appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
