### PR TITLE
Fix code scanning alert no. 188: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx.Headless.SDL2/Program.cs
+++ b/src/Ryujinx.Headless.SDL2/Program.cs
@@ -287,6 +287,13 @@ namespace Ryujinx.Headless.SDL2
                     profileBasePath = Path.Combine(AppDataManager.ProfilesDirPath, "controller");
                 }
 
+                // Validate inputProfileName to prevent directory traversal
+                if (inputProfileName.Contains("..") || inputProfileName.Contains("/") || inputProfileName.Contains("\\"))
+                {
+                    Logger.Error?.Print(LogClass.Application, $"Invalid input profile name \"{inputProfileName}\" for \"{inputId}\"");
+                    return null;
+                }
+
                 string path = Path.Combine(profileBasePath, inputProfileName + ".json");
 
                 if (!File.Exists(path))


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/188](https://github.com/ElProConLag/Ryujinx/security/code-scanning/188)

To fix the problem, we need to validate the `inputProfileName` before using it to construct the file path. Specifically, we should ensure that `inputProfileName` does not contain any path separators or sequences that could lead to directory traversal (e.g., ".."). This can be done by checking for the presence of such characters and rejecting the input if any are found.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
