### PR TITLE
Fix code scanning alert no. 184: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx.HLE/Loaders/Processes/Extensions/PartitionFileSystemExtensions.cs
+++ b/src/Ryujinx.HLE/Loaders/Processes/Extensions/PartitionFileSystemExtensions.cs
@@ -119,7 +119,13 @@ namespace Ryujinx.HLE.Loaders.Processes.Extensions
 
                 // Load DownloadableContents.
                 string addOnContentMetadataPath = System.IO.Path.Combine(AppDataManager.GamesDirPath, mainNca.GetProgramIdBase().ToString("x16"), "dlc.json");
-                if (File.Exists(addOnContentMetadataPath))
+                string fullAddOnContentMetadataPath = Path.GetFullPath(addOnContentMetadataPath);
+                if (!fullAddOnContentMetadataPath.StartsWith(Path.GetFullPath(AppDataManager.GamesDirPath) + Path.DirectorySeparatorChar))
+                {
+                    Logger.Warning?.Print(LogClass.Application, $"Invalid AddOnContent metadata path: {addOnContentMetadataPath}");
+                    return (false, ProcessResult.Failed);
+                }
+                if (File.Exists(fullAddOnContentMetadataPath))
                 {
                     List<DownloadableContentContainer> dlcContainerList = JsonHelper.DeserializeFromFile(addOnContentMetadataPath, _contentSerializerContext.ListDownloadableContentContainer);
 


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/184](https://github.com/ElProConLag/Ryujinx/security/code-scanning/184)

To fix the problem, we need to validate the constructed path to ensure it does not contain any directory traversal sequences or point outside the intended directory. We can achieve this by checking that the resolved path is still within the expected base directory.

1. Validate the `addOnContentMetadataPath` to ensure it is within the `AppDataManager.GamesDirPath`.
2. Use `Path.GetFullPath` to resolve the absolute path and compare it with the base directory to ensure it does not escape the intended directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
