### PR TITLE
Fix code scanning alert no. 179: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx.HLE/HOS/Services/Nfc/Nfp/VirtualAmiibo.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Nfc/Nfp/VirtualAmiibo.cs
@@ -165,7 +165,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
 
         private static VirtualAmiiboFile LoadAmiiboFile(string amiiboId)
         {
-            if (amiiboId.Contains("..") || amiiboId.Contains("/") || amiiboId.Contains("\\"))
+            if (amiiboId.Contains("..") || amiiboId.Contains("/") || amiiboId.Contains("\\") || amiiboId.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
             {
                 throw new ArgumentException("Invalid amiiboId");
             }
@@ -179,7 +179,12 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
 
             Directory.CreateDirectory(amiiboDir);
 
-            string filePath = Path.Join(amiiboDir, $"{amiiboId}.json");
+            string filePath = Path.GetFullPath(Path.Join(amiiboDir, $"{amiiboId}.json"));
+
+            if (!filePath.StartsWith(amiiboDir))
+            {
+                throw new UnauthorizedAccessException("Invalid file path");
+            }
 
             VirtualAmiiboFile virtualAmiiboFile;
 
@@ -208,7 +213,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
 
         private static void SaveAmiiboFile(VirtualAmiiboFile virtualAmiiboFile)
         {
-            if (virtualAmiiboFile.AmiiboId.Contains("..") || virtualAmiiboFile.AmiiboId.Contains("/") || virtualAmiiboFile.AmiiboId.Contains("\\"))
+            if (virtualAmiiboFile.AmiiboId.Contains("..") || virtualAmiiboFile.AmiiboId.Contains("/") || virtualAmiiboFile.AmiiboId.Contains("\\") || virtualAmiiboFile.AmiiboId.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
             {
                 throw new ArgumentException("Invalid amiiboId");
             }
@@ -220,7 +225,13 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
                 throw new UnauthorizedAccessException("Invalid path");
             }
 
-            string filePath = Path.Join(amiiboDir, $"{virtualAmiiboFile.AmiiboId}.json");
+            string filePath = Path.GetFullPath(Path.Join(amiiboDir, $"{virtualAmiiboFile.AmiiboId}.json"));
+
+            if (!filePath.StartsWith(amiiboDir))
+            {
+                throw new UnauthorizedAccessException("Invalid file path");
+            }
+
             JsonHelper.SerializeToFile(filePath, virtualAmiiboFile, _serializerContext.VirtualAmiiboFile);
         }
     }


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/179](https://github.com/ElProConLag/Ryujinx/security/code-scanning/179)

To fix the problem, we need to ensure that the constructed file paths are safe and do not allow for path traversal attacks. This can be achieved by:
1. Validating the `amiiboId` more thoroughly to ensure it does not contain any path traversal sequences.
2. Ensuring that the `BaseDirPath` is a trusted directory and not manipulated by external inputs.
3. Using `Path.GetFullPath` to resolve the final file path and ensuring it is within the expected directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
