### PR TITLE
Fix code scanning alert no. 204: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx.Common/Configuration/AppDataManager.cs
+++ b/src/Ryujinx.Common/Configuration/AppDataManager.cs
@@ -108,6 +108,12 @@ namespace Ryujinx.Common.Configuration
 
             BaseDirPath = Path.GetFullPath(BaseDirPath); // convert relative paths
 
+            // Validate the BaseDirPath to prevent path traversal
+            if (BaseDirPath.Contains("..") || BaseDirPath.Contains("/") || BaseDirPath.Contains("\\"))
+            {
+                throw new InvalidOperationException("Invalid base directory path detected.");
+            }
+
             if (IsPathSymlink(BaseDirPath))
             {
                 Logger.Warning?.Print(LogClass.Application, $"Application data directory is a symlink. This may be unintended.");

--- a/src/Ryujinx.Gtk3/UI/Windows/AmiiboWindow.cs
+++ b/src/Ryujinx.Gtk3/UI/Windows/AmiiboWindow.cs
@@ -68,7 +68,7 @@ namespace Ryujinx.UI.Windows
 
             // Validate the constructed path
             string fullPath = Path.GetFullPath(_amiiboJsonPath);
-            if (!fullPath.StartsWith(amiiboDir + Path.DirectorySeparatorChar))
+            if (!fullPath.StartsWith(amiiboDir + Path.DirectorySeparatorChar) || fullPath.Contains(".."))
             {
                 Logger.Error?.Print(LogClass.Application, $"Invalid path detected: {_amiiboJsonPath}");
                 throw new InvalidOperationException("Invalid path detected.");


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/204](https://github.com/ElProConLag/Ryujinx/security/code-scanning/204)

To fix the problem, we need to ensure that the `BaseDirPath` and any derived paths are properly validated to prevent path traversal attacks. This involves:
1. Normalizing the `BaseDirPath` to ensure it is an absolute path.
2. Ensuring that the `BaseDirPath` does not contain any path traversal sequences like "..".
3. Validating that the constructed `amiiboDir` and `_amiiboJsonPath` are within the expected directory structure.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
