### PR TITLE
Fix code scanning alert no. 157: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx.Gtk3/UI/Windows/ControllerWindow.cs
+++ b/src/Ryujinx.Gtk3/UI/Windows/ControllerWindow.cs
@@ -1118,6 +1118,12 @@ namespace Ryujinx.UI.Windows
             }
             else
             {
+                if (_profile.ActiveId.Contains("..") || _profile.ActiveId.Contains("/") || _profile.ActiveId.Contains("\\"))
+                {
+                    Logger.Warning?.Print(LogClass.Application, "Invalid profile ID detected.");
+                    return;
+                }
+
                 string path = System.IO.Path.Combine(GetProfileBasePath(), _profile.ActiveId);
 
                 if (!File.Exists(path))


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/157](https://github.com/ElProConLag/Ryujinx/security/code-scanning/157)

To fix the problem, we need to validate the user input before using it to construct a file path. Specifically, we should ensure that the `_profile.ActiveId` does not contain any path traversal characters or sequences. We can achieve this by implementing a validation method that checks for the presence of "..", "/", and "\\" in the `_profile.ActiveId` and rejects the input if any are found.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
