### PR TITLE
Fix code scanning alert no. 153: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx.Gtk3/UI/Windows/CheatWindow.cs
+++ b/src/Ryujinx.Gtk3/UI/Windows/CheatWindow.cs
@@ -30,6 +30,11 @@ namespace Ryujinx.UI.Windows
         {
             builder.Autoconnect(this);
 
+            bool IsValidPath(string path)
+            {
+                return !path.Contains("..") && !path.Contains("/") && !path.Contains("\\");
+            }
+
             IntegrityCheckLevel checkLevel = ConfigurationState.Instance.System.EnableFsIntegrityChecks
                 ? IntegrityCheckLevel.ErrorOnInvalid
                 : IntegrityCheckLevel.None;
@@ -41,6 +46,11 @@ namespace Ryujinx.UI.Windows
             string titleModsPath = ModLoader.GetApplicationDir(modsBasePath, titleId.ToString("X16"));
 
             _enabledCheatsPath = System.IO.Path.Combine(titleModsPath, "cheats", "enabled.txt");
+
+            if (!IsValidPath(_enabledCheatsPath))
+            {
+                throw new InvalidOperationException("Invalid path detected.");
+            }
 
             _cheatTreeView.Model = new TreeStore(typeof(bool), typeof(string), typeof(string), typeof(string));
 


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/153](https://github.com/ElProConLag/Ryujinx/security/code-scanning/153)

To fix the problem, we need to ensure that the path `_enabledCheatsPath` is validated before it is used in file operations. This involves checking that the path does not contain any invalid sequences such as "..", "/", or "\\" and ensuring it is within a safe directory.

1. Add a method to validate the path before using it.
2. Use this method to validate `_enabledCheatsPath` before reading the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
