### PR TITLE
Fix code scanning alert no. 110: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx/UI/ViewModels/AmiiboWindowViewModel.cs
+++ b/src/Ryujinx/UI/ViewModels/AmiiboWindowViewModel.cs
@@ -223,7 +223,7 @@ namespace Ryujinx.Ava.UI.ViewModels
             {
                 try
                 {
-                    if (File.Exists(_amiiboJsonPath))
+                    if (IsPathWithinBaseDir(_amiiboJsonPath) && File.Exists(_amiiboJsonPath))
                     {
                         localIsValid = TryGetAmiiboJson(await File.ReadAllTextAsync(_amiiboJsonPath), out amiiboJson);
                     }
@@ -515,4 +515,11 @@ namespace Ryujinx.Ava.UI.ViewModels
                 LocaleManager.Instance[LocaleKeys.RyujinxInfo]);
         }
     }
+        private bool IsPathWithinBaseDir(string path)
+        {
+            string baseDirFullPath = Path.GetFullPath(AppDataManager.BaseDirPath);
+            string fullPath = Path.GetFullPath(path);
+
+            return fullPath.StartsWith(baseDirFullPath + Path.DirectorySeparatorChar);
+        }
 }


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/110](https://github.com/ElProConLag/Ryujinx/security/code-scanning/110)

To fix the problem, we need to ensure that the constructed path `_amiiboJsonPath` is within a safe directory. This can be achieved by validating the resolved path to ensure it is contained within the expected base directory. We will add a method to perform this validation and use it before accessing the file.

1. Add a method to validate that a path is within a specified base directory.
2. Use this method to validate `_amiiboJsonPath` before performing file operations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
