### PR TITLE
Fix code scanning alert no. 42: Uncontrolled data used in path expression

### DIFF
--- a/src/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/src/ARMeilleure/Translation/PTC/Ptc.cs
@@ -129,6 +129,17 @@ namespace ARMeilleure.Translation.PTC
             string workPathActual = Path.Combine(AppDataManager.GamesDirPath, TitleIdText, "cache", "cpu", ActualDir);
             string workPathBackup = Path.Combine(AppDataManager.GamesDirPath, TitleIdText, "cache", "cpu", BackupDir);
 
+            // Validate workPathActual and workPathBackup to prevent path traversal
+            string safeGamesDirPath = Path.GetFullPath(AppDataManager.GamesDirPath);
+            workPathActual = Path.GetFullPath(workPathActual);
+            workPathBackup = Path.GetFullPath(workPathBackup);
+
+            if (!workPathActual.StartsWith(safeGamesDirPath + Path.DirectorySeparatorChar) ||
+                !workPathBackup.StartsWith(safeGamesDirPath + Path.DirectorySeparatorChar))
+            {
+                throw new InvalidOperationException("Work path is outside the allowed directory.");
+            }
+
             if (!Directory.Exists(workPathActual))
             {
                 Directory.CreateDirectory(workPathActual);

--- a/src/Ryujinx.Common/Configuration/AppDataManager.cs
+++ b/src/Ryujinx.Common/Configuration/AppDataManager.cs
@@ -114,6 +114,13 @@ namespace Ryujinx.Common.Configuration
                 throw new InvalidOperationException("Invalid base directory path detected.");
             }
 
+            // Ensure BaseDirPath is within a safe directory
+            string safeBaseDir = Path.GetFullPath(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData));
+            if (!BaseDirPath.StartsWith(safeBaseDir + Path.DirectorySeparatorChar))
+            {
+                throw new InvalidOperationException("Base directory path is outside the allowed directory.");
+            }
+
             if (IsPathSymlink(BaseDirPath))
             {
                 Logger.Warning?.Print(LogClass.Application, $"Application data directory is a symlink. This may be unintended.");


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/42](https://github.com/ElProConLag/Ryujinx/security/code-scanning/42)

To fix the problem, we need to ensure that the paths constructed from user-influenced data are validated properly before being used in file operations. Specifically, we should:
1. Normalize the paths to their absolute forms.
2. Ensure that the paths do not contain any ".." components or path separators that could lead to directory traversal.
3. Ensure that the paths are contained within a safe directory.

We will implement these changes in the `Initialize` method of `AppDataManager` and the method in `Ptc` where the paths are used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
