### PR TITLE
Fix code scanning alert no. 200: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx/Modules/Updater/Updater.cs
+++ b/src/Ryujinx/Modules/Updater/Updater.cs
@@ -37,7 +37,21 @@ namespace Ryujinx.Modules
         private static readonly string _homeDir = AppDomain.CurrentDomain.BaseDirectory;
         private static readonly string _updateDir = Path.Combine(Path.GetTempPath(), "Ryujinx", "update");
         private static readonly string _updatePublishDir = Path.Combine(_updateDir, "publish");
+
+        static Updater()
+        {
+            ValidatePathWithinDirectory(Path.GetTempPath(), _updateDir);
+        }
         private const int ConnectionCount = 4;
+
+        private static void ValidatePathWithinDirectory(string baseDir, string path)
+        {
+            string fullPath = Path.GetFullPath(path);
+            if (!fullPath.StartsWith(Path.GetFullPath(baseDir) + Path.DirectorySeparatorChar))
+            {
+                throw new UnauthorizedAccessException("Attempt to access outside of the base directory.");
+            }
+        }
 
         private static string _buildVer;
         private static string _platformExt;
@@ -518,6 +532,7 @@ namespace Ryujinx.Modules
         private static void ExtractTarGzipFile(TaskDialog taskDialog, string archivePath, string outputDirectoryPath)
         {
             ValidatePath(outputDirectoryPath);
+            ValidatePathWithinDirectory(_updateDir, outputDirectoryPath);
 
             using Stream inStream = File.OpenRead(archivePath);
             using GZipInputStream gzipStream = new(inStream);
@@ -563,6 +578,7 @@ namespace Ryujinx.Modules
         private static void ExtractZipFile(TaskDialog taskDialog, string archivePath, string outputDirectoryPath)
         {
             ValidatePath(outputDirectoryPath);
+            ValidatePathWithinDirectory(_updateDir, outputDirectoryPath);
 
             using Stream inStream = File.OpenRead(archivePath);
             using ZipFile zipFile = new(inStream);


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/200](https://github.com/ElProConLag/Ryujinx/security/code-scanning/200)

To fix the problem, we need to ensure that the `_updateDir` path is validated to be within a safe directory. We can achieve this by normalizing the path and checking that it starts with a known safe directory. Additionally, we should validate the `outputDirectoryPath` in the `ExtractTarGzipFile` and `ExtractZipFile` methods to ensure they are within the intended directory.

1. Add a method to validate that a path is within a specific directory.
2. Use this method to validate `_updateDir` after it is constructed.
3. Ensure that `outputDirectoryPath` is validated in the `ExtractTarGzipFile` and `ExtractZipFile` methods.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
