### PR TITLE
Fix code scanning alert no. 103: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx/UI/ViewModels/Input/InputViewModel.cs
+++ b/src/Ryujinx/UI/ViewModels/Input/InputViewModel.cs
@@ -491,7 +491,14 @@ namespace Ryujinx.Ava.UI.ViewModels.Input
                 path = Path.Combine(path, ControllerString);
             }
 
-            return path;
+            // Validate the path to ensure it is within the ProfilesDirPath
+            string fullPath = Path.GetFullPath(path);
+            if (!fullPath.StartsWith(AppDataManager.ProfilesDirPath))
+            {
+                throw new InvalidOperationException("Invalid profile base path detected.");
+            }
+
+            return fullPath;
         }
 
         private void LoadProfiles()


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/103](https://github.com/ElProConLag/Ryujinx/security/code-scanning/103)

To fix the problem, we need to ensure that the `basePath` used in `LoadProfiles` is properly validated to prevent path traversal attacks. This involves checking that the resolved path is within a specific directory and does not contain any invalid characters or sequences.

1. Modify the `GetProfileBasePath` method to validate the constructed path.
2. Ensure that the `basePath` in `LoadProfiles` is within a safe directory before using it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
