### PR TITLE
Fix code scanning alert no. 90: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx/UI/Controls/ApplicationContextMenu.axaml.cs
+++ b/src/Ryujinx/UI/Controls/ApplicationContextMenu.axaml.cs
@@ -283,13 +283,19 @@ namespace Ryujinx.Ava.UI.Controls
             if (viewModel?.SelectedApplication != null)
             {
                 string shaderCacheDir = Path.Combine(AppDataManager.GamesDirPath, viewModel.SelectedApplication.IdString, "cache", "shader");
+                string normalizedShaderCacheDir = Path.GetFullPath(shaderCacheDir);
 
-                if (!Directory.Exists(shaderCacheDir))
+                if (!normalizedShaderCacheDir.StartsWith(Path.GetFullPath(AppDataManager.GamesDirPath) + Path.DirectorySeparatorChar))
                 {
-                    Directory.CreateDirectory(shaderCacheDir);
+                    throw new UnauthorizedAccessException("Invalid path");
                 }
 
-                OpenHelper.OpenFolder(shaderCacheDir);
+                if (!Directory.Exists(normalizedShaderCacheDir))
+                {
+                    Directory.CreateDirectory(normalizedShaderCacheDir);
+                }
+
+                OpenHelper.OpenFolder(normalizedShaderCacheDir);
             }
         }
 


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/90](https://github.com/ElProConLag/Ryujinx/security/code-scanning/90)

To fix the problem, we need to validate the constructed path to ensure it does not contain any malicious components that could lead to directory traversal vulnerabilities. We will:
1. Normalize the constructed path.
2. Ensure the path is within the expected base directory.

We will implement these changes in the `OpenShaderCacheDirectory_Click` method in `src/Ryujinx/UI/Controls/ApplicationContextMenu.axaml.cs`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
