### PR TITLE
Fix code scanning alert no. 155: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx.Gtk3/UI/Windows/ControllerWindow.cs
+++ b/src/Ryujinx.Gtk3/UI/Windows/ControllerWindow.cs
@@ -785,6 +785,13 @@ namespace Ryujinx.UI.Windows
             return fullPath.StartsWith(basePath + Path.DirectorySeparatorChar);
         }
 
+        private bool IsBasePathValid(string basePath)
+        {
+            string profilesDirPath = Path.GetFullPath(AppDataManager.ProfilesDirPath);
+            string fullPath = Path.GetFullPath(basePath);
+            return fullPath.StartsWith(profilesDirPath + Path.DirectorySeparatorChar);
+        }
+
         //
         // Events
         //
@@ -951,6 +958,12 @@ namespace Ryujinx.UI.Windows
             _profile.RemoveAll();
 
             string basePath = GetProfileBasePath();
+
+            if (!IsBasePathValid(basePath))
+            {
+                Logger.Error.Print(LogClass.Application, "Invalid base path for profiles.");
+                return;
+            }
 
             if (!Directory.Exists(basePath))
             {


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/155](https://github.com/ElProConLag/Ryujinx/security/code-scanning/155)

To fix the problem, we need to validate the `basePath` before using it in file system operations. Specifically, we should ensure that the `basePath` is within a predefined safe directory. This can be done by checking that the resolved path starts with the expected base directory path.

1. Add a method `IsPathValid` to validate that the `basePath` is within the expected directory.
2. Use this validation method in the `SetProfiles` method before performing any file system operations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
