### PR TITLE
Fix code scanning alert no. 134: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx.Gtk3/Program.cs
+++ b/src/Ryujinx.Gtk3/Program.cs
@@ -158,6 +158,13 @@ namespace Ryujinx
             string localConfigurationPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ReleaseInformation.ConfigName);
             string appDataConfigurationPath = Path.Combine(AppDataManager.BaseDirPath, ReleaseInformation.ConfigName);
 
+            // Validate appDataConfigurationPath to ensure it is within the expected base directory
+            if (!Path.GetFullPath(appDataConfigurationPath).StartsWith(Path.GetFullPath(AppDataManager.BaseDirPath) + Path.DirectorySeparatorChar))
+            {
+                Logger.Error?.Print(LogClass.Application, $"Invalid configuration path: {appDataConfigurationPath}. Falling back to default configuration path.");
+                appDataConfigurationPath = null;
+            }
+
             // Now load the configuration as the other subsystems are now registered
             ConfigurationPath = File.Exists(localConfigurationPath)
                 ? localConfigurationPath


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/134](https://github.com/ElProConLag/Ryujinx/security/code-scanning/134)

To fix the problem, we need to ensure that the constructed path `appDataConfigurationPath` is validated to be within a safe directory. This can be done by checking that the resolved path starts with the expected base directory path. If the path is not within the expected directory, we should handle it appropriately, such as by logging an error and falling back to a default safe path.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
