### PR TITLE
Fix code scanning alert no. 171: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx.Common/Configuration/AppDataManager.cs
+++ b/src/Ryujinx.Common/Configuration/AppDataManager.cs
@@ -83,7 +83,7 @@ namespace Ryujinx.Common.Configuration
 
             if (baseDirPath != null && baseDirPath != userProfilePath)
             {
-                if (baseDirPath.Contains("..") || baseDirPath.Contains("/") || baseDirPath.Contains("\\"))
+                if (baseDirPath.Contains("..") || baseDirPath.Contains("/") || baseDirPath.Contains("\\") || baseDirPath.IndexOfAny(Path.GetInvalidPathChars()) >= 0)
                 {
                     Logger.Error?.Print(LogClass.Application, $"Invalid custom data directory '{baseDirPath}'. Falling back to {Mode}...");
                 }

--- a/src/Ryujinx.HLE/FileSystem/ContentManager.cs
+++ b/src/Ryujinx.HLE/FileSystem/ContentManager.cs
@@ -557,7 +557,12 @@ namespace Ryujinx.HLE.FileSystem
 
         public static void SaveNca(Nca nca, string ncaId, string temporaryDirectory)
         {
-            string newPath = Path.Combine(temporaryDirectory, ncaId + ".nca");
+            string newPath = Path.GetFullPath(Path.Combine(temporaryDirectory, ncaId + ".nca"));
+            string fullTempDirPath = Path.GetFullPath(temporaryDirectory + Path.DirectorySeparatorChar);
+            if (!newPath.StartsWith(fullTempDirPath))
+            {
+                throw new InvalidOperationException("Entry is outside the target dir: " + newPath);
+            }
 
             Directory.CreateDirectory(newPath);
 


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/171](https://github.com/ElProConLag/Ryujinx/security/code-scanning/171)

To fix the problem, we need to enhance the validation of the `baseDirPath` to ensure it does not contain any path traversal sequences or other potentially dangerous characters. Additionally, we should ensure that the `temporaryDirectory` and `newPath` are always within a safe, predefined directory.

1. Enhance the validation of `baseDirPath` in `AppDataManager.Initialize` to ensure it does not contain any path traversal sequences or other potentially dangerous characters.
2. Ensure that `temporaryDirectory` and `newPath` are always within a safe, predefined directory by using `Path.GetFullPath` and checking that the resulting paths start with the expected base directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
