### PR TITLE
Fix code scanning alert no. 143: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx.Gtk3/UI/Widgets/GameTableContextMenu.cs
+++ b/src/Ryujinx.Gtk3/UI/Widgets/GameTableContextMenu.cs
@@ -514,6 +514,12 @@ namespace Ryujinx.UI.Widgets
 
         private void OpenPtcDir_Clicked(object sender, EventArgs args)
         {
+            if (ContainsInvalidPathChars(_applicationData.IdString))
+            {
+                // Handle invalid path case, e.g., show an error message to the user
+                return;
+            }
+
             string ptcDir = System.IO.Path.Combine(AppDataManager.GamesDirPath, _applicationData.IdString, "cache", "cpu");
 
             string mainPath = System.IO.Path.Combine(ptcDir, "0");
@@ -531,6 +537,12 @@ namespace Ryujinx.UI.Widgets
 
         private void OpenShaderCacheDir_Clicked(object sender, EventArgs args)
         {
+            if (ContainsInvalidPathChars(_applicationData.IdString))
+            {
+                // Handle invalid path case, e.g., show an error message to the user
+                return;
+            }
+
             string shaderCacheDir = System.IO.Path.Combine(AppDataManager.GamesDirPath, _applicationData.IdString, "cache", "shader");
 
             if (!Directory.Exists(shaderCacheDir))
@@ -631,4 +643,8 @@ namespace Ryujinx.UI.Widgets
             ShortcutHelper.CreateAppShortcut(_applicationData.Path, _applicationData.Name, _applicationData.IdString, appIcon);
         }
     }
+        private bool ContainsInvalidPathChars(string path)
+        {
+            return path.Contains("..") || path.Contains("/") || path.Contains("\\");
+        }
 }


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/143](https://github.com/ElProConLag/Ryujinx/security/code-scanning/143)

To fix the problem, we need to validate the user-provided data before using it to construct file paths. Specifically, we should ensure that `_applicationData.IdString` does not contain any path separators or sequences like ".." that could lead to directory traversal. We can achieve this by adding a validation check before constructing the paths.

1. Add a method to validate the user-provided data.
2. Use this method to check `_applicationData.IdString` before constructing the paths in `OpenPtcDir_Clicked` and `OpenShaderCacheDir_Clicked`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
