### PR TITLE
Fix code scanning alert no. 190: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx.UI.Common/Helper/ShortcutHelper.cs
+++ b/src/Ryujinx.UI.Common/Helper/ShortcutHelper.cs
@@ -11,6 +11,15 @@ namespace Ryujinx.UI.Common.Helper
 {
     public static class ShortcutHelper
     {
+        private static bool IsValidPath(string path)
+        {
+            // Check for invalid path characters and sequences
+            if (path.Contains("..") || path.Contains("/") || path.Contains("\\"))
+            {
+                return false;
+            }
+            return true;
+        }
         [SupportedOSPlatform("windows")]
         private static void CreateShortcutWindows(string applicationFilePath, string applicationId, byte[] iconData, string iconPath, string cleanedAppName, string desktopPath)
         {
@@ -33,6 +42,11 @@ namespace Ryujinx.UI.Common.Helper
             string basePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Ryujinx.sh");
             var desktopFile = EmbeddedResources.ReadAllText("Ryujinx.UI.Common/shortcut-template.desktop");
             iconPath += ".png";
+
+            if (!IsValidPath(iconPath))
+            {
+                throw new ArgumentException("Invalid icon path.");
+            }
 
             var image = SKBitmap.Decode(iconData);
             using var data = image.Encode(SKEncodedImageFormat.Png, 100);


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/190](https://github.com/ElProConLag/Ryujinx/security/code-scanning/190)

To fix the problem, we need to ensure that the `iconPath` is validated to prevent path traversal attacks. This can be done by checking that the resolved path is within a specific directory and does not contain any invalid characters or sequences.

1. **General Fix Approach:**
   - Validate the `iconPath` to ensure it does not contain any path traversal sequences like "..".
   - Ensure the resolved path is within a specific directory.

2. **Detailed Fix:**
   - Add a method to validate the `iconPath`.
   - Use this method to check the `iconPath` before using it in file operations.

3. **Specific Changes:**
   - Add a method `IsValidPath` to validate the path.
   - Use this method in the `CreateShortcutLinux` method to validate `iconPath`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
