### PR TITLE
Fix code scanning alert no. 69: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx/Modules/Updater/Updater.cs
+++ b/src/Ryujinx/Modules/Updater/Updater.cs
@@ -258,11 +258,13 @@ namespace Ryujinx.Modules
             _updateSuccessful = false;
 
             // Empty update dir, although it shouldn't ever have anything inside it
+            ValidatePathWithinDirectory(Path.GetTempPath(), _updateDir);
+
             if (Directory.Exists(_updateDir))
             {
                 Directory.Delete(_updateDir, true);
             }
-
+                
             Directory.CreateDirectory(_updateDir);
 
             string updateFile = Path.Combine(_updateDir, "update.bin");


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/69](https://github.com/ElProConLag/Ryujinx/security/code-scanning/69)

To fix the problem, we need to ensure that the path `_updateDir` is validated before it is used in any file system operations. This can be done by calling the `ValidatePathWithinDirectory` method before creating the directory. This ensures that even if the path is influenced by user-controlled environment variables, it will be checked for validity before any potentially dangerous operations are performed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
