### PR TITLE
Fix code scanning alert no. 209: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx/UI/Controls/ApplicationContextMenu.axaml.cs
+++ b/src/Ryujinx/UI/Controls/ApplicationContextMenu.axaml.cs
@@ -282,7 +282,15 @@ namespace Ryujinx.Ava.UI.Controls
 
             if (viewModel?.SelectedApplication != null)
             {
-                string shaderCacheDir = Path.Combine(AppDataManager.GamesDirPath, viewModel.SelectedApplication.IdString, "cache", "shader");
+                string idString = viewModel.SelectedApplication.IdString;
+
+                // Validate IdString to ensure it does not contain path traversal characters or sequences
+                if (idString.Contains("..") || idString.Contains("/") || idString.Contains("\\"))
+                {
+                    throw new UnauthorizedAccessException("Invalid application ID");
+                }
+
+                string shaderCacheDir = Path.Combine(AppDataManager.GamesDirPath, idString, "cache", "shader");
                 string normalizedShaderCacheDir = Path.GetFullPath(shaderCacheDir);
 
                 if (!normalizedShaderCacheDir.StartsWith(Path.GetFullPath(AppDataManager.GamesDirPath) + Path.DirectorySeparatorChar))


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/209](https://github.com/ElProConLag/Ryujinx/security/code-scanning/209)

To fix the problem, we need to ensure that the `viewModel.SelectedApplication.IdString` does not contain any path traversal characters or sequences. This can be done by validating the `IdString` to ensure it does not contain "..", "/", or "\\". Additionally, we should normalize the path and ensure it remains within the intended directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
