### PR TITLE
Fix code scanning alert no. 103: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx/UI/ViewModels/Input/InputViewModel.cs
+++ b/src/Ryujinx/UI/ViewModels/Input/InputViewModel.cs
@@ -491,9 +491,11 @@ namespace Ryujinx.Ava.UI.ViewModels.Input
                 path = Path.Combine(path, ControllerString);
             }
 
-            // Validate the path to ensure it is within the ProfilesDirPath
+            // Normalize and validate the path to ensure it is within the ProfilesDirPath
             string fullPath = Path.GetFullPath(path);
-            if (!fullPath.StartsWith(AppDataManager.ProfilesDirPath))
+            string baseDir = Path.GetFullPath(AppDataManager.ProfilesDirPath);
+
+            if (!fullPath.StartsWith(baseDir + Path.DirectorySeparatorChar) && fullPath != baseDir)
             {
                 throw new InvalidOperationException("Invalid profile base path detected.");
             }


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/103](https://github.com/ElProConLag/Ryujinx/security/code-scanning/103)

To fix the problem, we need to enhance the validation of the path to ensure it is within a safe directory. This involves:
1. Normalizing the path to remove any redundant or malicious components.
2. Ensuring the path is relative to a known safe base directory.
3. Rejecting any paths that attempt to traverse outside the intended directory.

We will update the `GetProfileBasePath` method to include these additional checks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
