### PR TITLE
Fix code scanning alert no. 43: Uncontrolled data used in path expression

### DIFF
--- a/src/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/src/ARMeilleure/Translation/PTC/Ptc.cs
@@ -134,7 +134,9 @@ namespace ARMeilleure.Translation.PTC
             workPathActual = Path.GetFullPath(workPathActual);
             workPathBackup = Path.GetFullPath(workPathBackup);
 
-            if (!workPathActual.StartsWith(safeGamesDirPath + Path.DirectorySeparatorChar) ||
+            if (workPathActual.Contains("..") || workPathActual.Contains(Path.DirectorySeparatorChar.ToString()) ||
+                workPathBackup.Contains("..") || workPathBackup.Contains(Path.DirectorySeparatorChar.ToString()) ||
+                !workPathActual.StartsWith(safeGamesDirPath + Path.DirectorySeparatorChar) ||
                 !workPathBackup.StartsWith(safeGamesDirPath + Path.DirectorySeparatorChar))
             {
                 throw new InvalidOperationException("Work path is outside the allowed directory.");


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/43](https://github.com/ElProConLag/Ryujinx/security/code-scanning/43)

To fix the problem, we need to enhance the validation of the paths to ensure they do not contain any path traversal sequences and are strictly within the intended directory. This can be achieved by normalizing the paths and ensuring they do not contain any ".." sequences or path separators that could lead to directory traversal.

1. Normalize the paths using `Path.GetFullPath`.
2. Check that the normalized paths do not contain any ".." sequences or path separators.
3. Ensure the paths are within the intended base directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
