### PR TITLE
Fix code scanning alert no. 61: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx/Program.cs
+++ b/src/Ryujinx/Program.cs
@@ -135,6 +135,13 @@ namespace Ryujinx.Ava
             }
         }
 
+        private static bool IsValidPath(string basePath, string path)
+        {
+            string fullPath = Path.GetFullPath(path);
+            return fullPath.StartsWith(Path.GetFullPath(basePath) + Path.DirectorySeparatorChar) &&
+                   !path.Contains("..") && !path.Contains("/") && !path.Contains("\\");
+        }
+
         public static void ReloadConfig()
         {
             string localConfigurationPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ReleaseInformation.ConfigName);
@@ -145,7 +152,7 @@ namespace Ryujinx.Ava
             {
                 ConfigurationPath = localConfigurationPath;
             }
-            else if (File.Exists(appDataConfigurationPath))
+            else if (IsValidPath(AppDataManager.BaseDirPath, appDataConfigurationPath) && File.Exists(appDataConfigurationPath))
             {
                 ConfigurationPath = appDataConfigurationPath;
             }


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/61](https://github.com/ElProConLag/Ryujinx/security/code-scanning/61)

To fix the problem, we need to ensure that the path constructed using `AppDataManager.BaseDirPath` is validated before it is used. Specifically, we should ensure that the path is within a safe directory and does not contain any ".." sequences or path separators that could lead to directory traversal attacks.

1. Add a method to validate the path by checking that it is within a specific directory and does not contain any ".." sequences or path separators.
2. Use this validation method in the `ReloadConfig` method before using `appDataConfigurationPath`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
