### PR TITLE
Fix code scanning alert no. 112: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx/UI/ViewModels/ModManagerViewModel.cs
+++ b/src/Ryujinx/UI/ViewModels/ModManagerViewModel.cs
@@ -189,6 +189,19 @@ namespace Ryujinx.Ava.UI.ViewModels
             var basePath = model.InSd ? ModLoader.GetSdModsBasePath() : ModLoader.GetModsBasePath();
             var modsDir = ModLoader.GetApplicationDir(basePath, _applicationId.ToString("x16"));
 
+            // Validate modsDir to ensure it is within a safe directory
+            var safeBaseDir = Path.GetFullPath(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData));
+            if (!modsDir.StartsWith(safeBaseDir + Path.DirectorySeparatorChar))
+            {
+                Dispatcher.UIThread.Post(async () =>
+                {
+                    await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance.UpdateAndGetDynamicValue(
+                        LocaleKeys.DialogModDeleteNoParentMessage,
+                        model.Path));
+                });
+                return;
+            }
+
             if (new DirectoryInfo(model.Path).Parent?.FullName == modsDir)
             {
                 isSubdir = false;


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/112](https://github.com/ElProConLag/Ryujinx/security/code-scanning/112)

To fix the problem, we need to ensure that the `modsDir` path is validated before it is used in the `Delete` method. Specifically, we should check that the `modsDir` path is within a safe directory and does not contain any path traversal sequences. We can achieve this by normalizing the path and ensuring it starts with a known safe base directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
