### PR TITLE
Fix code scanning alert no. 93: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx/UI/Windows/CheatWindow.axaml.cs
+++ b/src/Ryujinx/UI/Windows/CheatWindow.axaml.cs
@@ -35,6 +35,16 @@ namespace Ryujinx.Ava.UI.Windows
 
         public CheatWindow(VirtualFileSystem virtualFileSystem, string titleId, string titleName, string titlePath)
         {
+            if (string.IsNullOrWhiteSpace(titleId) || titleId.Contains("..") || titleId.Contains("/") || titleId.Contains("\\"))
+            {
+                throw new ArgumentException("Invalid titleId");
+            }
+
+            if (string.IsNullOrWhiteSpace(titlePath) || titlePath.Contains("..") || titlePath.Contains("/") || titlePath.Contains("\\"))
+            {
+                throw new ArgumentException("Invalid titlePath");
+            }
+
             LoadedCheats = new AvaloniaList<CheatNode>();
             IntegrityCheckLevel checkLevel = ConfigurationState.Instance.System.EnableFsIntegrityChecks
                 ? IntegrityCheckLevel.ErrorOnInvalid


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/93](https://github.com/ElProConLag/Ryujinx/security/code-scanning/93)

To fix the problem, we need to ensure that the user-provided values used to construct file paths are properly validated and sanitized. This involves:
1. Validating the `titleId` and `titlePath` to ensure they do not contain any path traversal characters or sequences.
2. Ensuring that the constructed paths remain within a designated safe directory.

We will add validation checks for `titleId` and `titlePath` before using them to construct `_enabledCheatsPath`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
