### PR TITLE
Fix code scanning alert no. 99: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx/UI/ViewModels/DownloadableContentManagerViewModel.cs
+++ b/src/Ryujinx/UI/ViewModels/DownloadableContentManagerViewModel.cs
@@ -105,6 +105,11 @@ namespace Ryujinx.Ava.UI.ViewModels
 
             _downloadableContentJsonPath = Path.Combine(AppDataManager.GamesDirPath, applicationData.IdBaseString, "dlc.json");
 
+            if (!IsPathValid(_downloadableContentJsonPath, AppDataManager.GamesDirPath))
+            {
+                throw new UnauthorizedAccessException("Invalid path detected.");
+            }
+
             if (!File.Exists(_downloadableContentJsonPath))
             {
                 _downloadableContentContainerList = new List<DownloadableContentContainer>();
@@ -123,6 +128,14 @@ namespace Ryujinx.Ava.UI.ViewModels
             }
 
             LoadDownloadableContents();
+        }
+
+        private bool IsPathValid(string path, string baseDir)
+        {
+            string fullPath = Path.GetFullPath(path);
+            string fullBaseDir = Path.GetFullPath(baseDir);
+
+            return fullPath.StartsWith(fullBaseDir + Path.DirectorySeparatorChar);
         }
 
         private void LoadDownloadableContents()


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/99](https://github.com/ElProConLag/Ryujinx/security/code-scanning/99)

To fix the problem, we need to validate the constructed path `_downloadableContentJsonPath` to ensure it does not contain any malicious components such as `..` or unexpected path separators. We can achieve this by checking that the resolved path is still contained within the intended directory.

1. Introduce a method to validate the path by ensuring it is within the `GamesDirPath`.
2. Use this method to validate `_downloadableContentJsonPath` before using it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
