### PR TITLE
Fix code scanning alert no. 101: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx.Common/Utilities/JsonHelper.cs
+++ b/src/Ryujinx.Common/Utilities/JsonHelper.cs
@@ -43,6 +43,10 @@ namespace Ryujinx.Common.Utilities
 
         public static void SerializeToFile<T>(string filePath, T value, JsonTypeInfo<T> typeInfo)
         {
+            if (!IsValidPath(filePath))
+            {
+                throw new ArgumentException("Invalid file path.");
+            }
             using FileStream file = File.Create(filePath, DefaultFileWriteBufferSize, FileOptions.WriteThrough);
             JsonSerializer.Serialize(file, value, typeInfo);
         }


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/101](https://github.com/ElProConLag/Ryujinx/security/code-scanning/101)

To fix the problem, we need to validate the `filePath` parameter in the `SerializeToFile` method to ensure it does not contain any invalid or dangerous path components. We can reuse the existing `IsValidPath` method for this purpose. This method checks that the path is within a specific base directory and does not contain any parent directory references or other special characters that could lead to directory traversal.

**Steps to fix:**
1. Add a validation check using the `IsValidPath` method in the `SerializeToFile` method.
2. If the path is invalid, throw an `ArgumentException`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
