### PR TITLE
Fix code scanning alert no. 161: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx.Gtk3/UI/Windows/AmiiboWindow.cs
+++ b/src/Ryujinx.Gtk3/UI/Windows/AmiiboWindow.cs
@@ -68,7 +68,7 @@ namespace Ryujinx.UI.Windows
 
             // Validate the constructed path
             string fullPath = Path.GetFullPath(_amiiboJsonPath);
-            if (!fullPath.StartsWith(amiiboDir + Path.DirectorySeparatorChar) || fullPath.Contains(".."))
+            if (!fullPath.StartsWith(Path.GetFullPath(amiiboDir) + Path.DirectorySeparatorChar))
             {
                 Logger.Error?.Print(LogClass.Application, $"Invalid path detected: {_amiiboJsonPath}");
                 throw new InvalidOperationException("Invalid path detected.");


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/161](https://github.com/ElProConLag/Ryujinx/security/code-scanning/161)

To fix the problem, we need to ensure that the constructed path `_amiiboJsonPath` is within a safe directory and does not contain any directory traversal sequences. We can achieve this by normalizing the path and checking that it starts with the expected base directory.

1. Normalize the constructed path using `Path.GetFullPath`.
2. Check that the normalized path starts with the expected base directory.
3. If the path is invalid, log an error and throw an exception.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
