### PR TITLE
Fix code scanning alert no. 157: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx.Gtk3/UI/Windows/ControllerWindow.cs
+++ b/src/Ryujinx.Gtk3/UI/Windows/ControllerWindow.cs
@@ -1137,9 +1137,17 @@ namespace Ryujinx.UI.Windows
                     return;
                 }
 
-                string path = System.IO.Path.Combine(GetProfileBasePath(), _profile.ActiveId);
+                string basePath = GetProfileBasePath();
+                string path = System.IO.Path.Combine(basePath, _profile.ActiveId);
+                string fullPath = Path.GetFullPath(path);
 
-                if (!File.Exists(path))
+                if (!fullPath.StartsWith(basePath + Path.DirectorySeparatorChar))
+                {
+                    Logger.Warning?.Print(LogClass.Application, "Invalid profile path detected.");
+                    return;
+                }
+
+                if (!File.Exists(fullPath))
                 {
                     if (pos >= 0)
                     {


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/157](https://github.com/ElProConLag/Ryujinx/security/code-scanning/157)

To fix the problem, we need to ensure that the constructed path remains within a specific directory and does not allow any form of path traversal. This can be achieved by normalizing the path and checking that it starts with the expected base directory.

1. Normalize the constructed path using `Path.GetFullPath`.
2. Check that the normalized path starts with the base directory path.
3. If the path is invalid, log a warning and return early.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
