### PR TITLE
Fix code scanning alert no. 133: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Numerics;
 using System.Runtime.CompilerServices;
+using System.Linq;
 
 namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
 {
@@ -194,14 +195,15 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         /// <param name="basePath">Base path of the shader cache</param>
         public DiskCacheHostStorage(string basePath)
         {
-            _basePath = basePath;
-            _guestStorage = new DiskCacheGuestStorage(basePath);
+            _basePath = ValidateBasePath(basePath);
+            _guestStorage = new DiskCacheGuestStorage(_basePath);
 
             if (CacheEnabled)
             {
-                Directory.CreateDirectory(basePath);
+                Directory.CreateDirectory(_basePath);
             }
         }
+
 
         /// <summary>
         /// Gets the total of host programs on the cache.
@@ -867,4 +869,16 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
             }
         }
     }
-}
+        private string ValidateBasePath(string basePath)
+        {
+            string safeBaseDir = Path.GetFullPath(AppDataManager.GamesDirPath);
+            string fullPath = Path.GetFullPath(basePath);
+
+            if (!fullPath.StartsWith(safeBaseDir) || fullPath.Any(c => Path.GetInvalidPathChars().Contains(c)))
+            {
+                throw new ArgumentException("Invalid base path");
+            }
+
+            return fullPath;
+        }
+    }


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/133](https://github.com/ElProConLag/Ryujinx/security/code-scanning/133)

To fix the problem, we need to validate the `basePath` before using it to create directories. We can ensure that the `basePath` is within a specific directory and does not contain any path traversal sequences like "..". This can be achieved by resolving the full path and checking that it starts with a known safe base directory.

1. Validate the `basePath` to ensure it does not contain any path traversal sequences.
2. Ensure that the resolved path is within a specific safe directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
