### PR TITLE
Fix code scanning alert no. 66: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx.Gtk3/Modules/Updater/Updater.cs
+++ b/src/Ryujinx.Gtk3/Modules/Updater/Updater.cs
@@ -533,6 +533,7 @@ namespace Ryujinx.Modules
                 MoveAllFilesOver(_updatePublishDir, _homeDir, updateDialog);
             });
 
+            Updater.ValidatePathWithinDirectory(Path.GetTempPath(), _updateDir);
             Directory.Delete(_updateDir, true);
 
             updateDialog.MainText.Text = "Update Complete!";


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/66](https://github.com/ElProConLag/Ryujinx/security/code-scanning/66)

To fix the problem, we need to ensure that `_updateDir` is validated to confirm it is within a safe directory. This can be done by using the `ValidatePathWithinDirectory` method already defined in the `Updater` class. We should call this validation method for `_updateDir` before any operations are performed on it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
