### PR TITLE
Fix code scanning alert no. 37: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx.Gtk3/UI/RendererWidgetBase.cs
+++ b/src/Ryujinx.Gtk3/UI/RendererWidgetBase.cs
@@ -382,21 +382,28 @@ namespace Ryujinx.UI
 
                         string filename = $"{sanitizedApplicationName}_{currentTime.Year}-{currentTime.Month:D2}-{currentTime.Day:D2}_{currentTime.Hour:D2}-{currentTime.Minute:D2}-{currentTime.Second:D2}.png";
 
-                        string directory = AppDataManager.Mode switch
+                        string baseDirectory = AppDataManager.Mode switch
                         {
                             AppDataManager.LaunchMode.Portable or AppDataManager.LaunchMode.Custom => System.IO.Path.Combine(AppDataManager.BaseDirPath, "screenshots"),
                             _ => System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyPictures), "Ryujinx"),
                         };
 
-                        string path = System.IO.Path.Combine(directory, filename);
+                        string path = System.IO.Path.Combine(baseDirectory, filename);
+
+                        // Validate that the path is within the intended directory
+                        if (!path.StartsWith(baseDirectory + Path.DirectorySeparatorChar))
+                        {
+                            Logger.Error?.Print(LogClass.Application, $"Invalid path: {path}", "Screenshot");
+                            return;
+                        }
 
                         try
                         {
-                            Directory.CreateDirectory(directory);
+                            Directory.CreateDirectory(baseDirectory);
                         }
                         catch (Exception ex)
                         {
-                            Logger.Error?.Print(LogClass.Application, $"Failed to create directory at path {directory}. Error : {ex.GetType().Name}", "Screenshot");
+                            Logger.Error?.Print(LogClass.Application, $"Failed to create directory at path {baseDirectory}. Error : {ex.GetType().Name}", "Screenshot");
 
                             return;
                         }


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/37](https://github.com/ElProConLag/Ryujinx/security/code-scanning/37)

To fix the problem, we need to ensure that the constructed path remains within a safe directory. This can be achieved by validating the resolved path after combining it with the base directory and the filename. Specifically, we should check that the final path starts with the expected base directory path.

1. Construct the base directory path using `Environment.GetFolderPath(Environment.SpecialFolder.MyPictures)` or the custom path.
2. Combine the base directory path with the sanitized filename to get the full path.
3. Validate that the full path starts with the base directory path to ensure it does not escape the intended directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
