### PR TITLE
Fix code scanning alert no. 182: Uncontrolled data used in path expression

### DIFF
--- a/src/Ryujinx.HLE/HOS/Services/Ssl/BuiltInCertificateManager.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ssl/BuiltInCertificateManager.cs
@@ -91,6 +91,11 @@ namespace Ryujinx.HLE.HOS.Services.Ssl
         {
             string customCertificatePath = System.IO.Path.Join(AppDataManager.BaseDirPath, "system", "ssl", $"{entry.Id}.der");
 
+            if (!IsPathSafe(customCertificatePath, AppDataManager.BaseDirPath))
+            {
+                throw new UnauthorizedAccessException("Invalid path detected.");
+            }
+
             byte[] data;
 
             if (File.Exists(customCertificatePath))
@@ -240,4 +245,9 @@ namespace Ryujinx.HLE.HOS.Services.Ssl
             }
         }
     }
+        private bool IsPathSafe(string path, string baseDir)
+        {
+            string fullPath = Path.GetFullPath(path);
+            return fullPath.StartsWith(Path.GetFullPath(baseDir) + Path.DirectorySeparatorChar) && !fullPath.Contains("..");
+        }
 }


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/182](https://github.com/ElProConLag/Ryujinx/security/code-scanning/182)

To fix the problem, we need to ensure that the constructed path `customCertificatePath` is validated to be within a safe directory. This can be achieved by checking that the resolved path starts with the expected base directory path and does not contain any special characters like "..".

1. Add a method to validate the constructed path.
2. Use this method to validate `customCertificatePath` before using it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
