### PR TITLE
Fix code scanning alert no. 21: Uncontrolled data used in path expression

### DIFF
--- a/distribution/macos/construct_universal_dylib.py
+++ b/distribution/macos/construct_universal_dylib.py
@@ -19,6 +19,12 @@ parser.add_argument("rglob", help="rglob")
 
 args = parser.parse_args()
 
+def validate_and_normalize_path(base_path: str, user_path: str) -> Path:
+    normalized_path = os.path.normpath(user_path)
+    if not normalized_path.startswith(base_path):
+        raise Exception(f"Path {user_path} is not allowed")
+    return Path(normalized_path)
+
 # Use Apple LLVM on Darwin, otherwise standard LLVM.
 if platform.system() == "Darwin":
     LIPO = "lipo"
@@ -35,9 +41,10 @@ else:
 if LIPO is None:
     raise Exception("Cannot find a valid location for LLVM lipo!")
 
-arm64_input_directory: Path = Path(args.arm64_input_directory)
-x86_64_input_directory: Path = Path(args.x86_64_input_directory)
-output_directory: Path = Path(args.output_directory)
+base_path = os.getcwd()
+arm64_input_directory: Path = validate_and_normalize_path(base_path, args.arm64_input_directory)
+x86_64_input_directory: Path = validate_and_normalize_path(base_path, args.x86_64_input_directory)
+output_directory: Path = validate_and_normalize_path(base_path, args.output_directory)
 rglob = args.rglob
 
 


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/21](https://github.com/ElProConLag/Ryujinx/security/code-scanning/21)

To fix the problem, we need to validate the user-provided paths to ensure they do not lead to directory traversal or access to unintended files. We can achieve this by normalizing the paths and ensuring they are within a specified safe root directory.

1. Normalize the user-provided paths using `os.path.normpath`.
2. Check that the normalized paths start with the expected base directory.
3. Raise an exception if the paths are not valid.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
