### PR TITLE
Fix code scanning alert no. 13: Uncontrolled data used in path expression

### DIFF
--- a/distribution/macos/bundle_fix_up.py
+++ b/distribution/macos/bundle_fix_up.py
@@ -531,7 +531,9 @@ def write_bundle_data(
 
 input_directory: Path = Path(args.input_directory)
 content_directory: Path = Path(os.path.join(args.input_directory, "Contents"))
-executable_path: Path = Path(os.path.join(content_directory, args.executable_sub_path))
+executable_path: Path = Path(os.path.normpath(os.path.join(content_directory, args.executable_sub_path)))
+if not str(executable_path).startswith(str(content_directory)):
+    raise ValueError("Executable path is outside the allowed directory")
 
 
 def get_path_related_to_other_path(a: Path, b: Path) -> str:


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/13](https://github.com/ElProConLag/Ryujinx/security/code-scanning/13)

To fix the problem, we need to validate the user-provided input to ensure it does not lead to unsafe file paths. We can achieve this by normalizing the path and ensuring it is contained within a safe root directory. This will prevent path traversal attacks and ensure that the constructed path is safe to use.

1. Normalize the `executable_path` using `os.path.normpath` to remove any ".." segments.
2. Check that the normalized path starts with the `content_directory` to ensure it is within the expected directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
