### PR TITLE
Fix code scanning alert no. 10: Uncontrolled data used in path expression

### DIFF
--- a/distribution/macos/bundle_fix_up.py
+++ b/distribution/macos/bundle_fix_up.py
@@ -529,9 +529,11 @@ def write_bundle_data(
     return total_size - new_bundle_base_offset
 
 
-input_directory: Path = Path(args.input_directory)
-content_directory: Path = Path(os.path.join(args.input_directory, "Contents"))
+input_directory: Path = Path(os.path.normpath(args.input_directory))
+content_directory: Path = Path(os.path.normpath(os.path.join(input_directory, "Contents")))
 executable_path: Path = Path(os.path.normpath(os.path.join(content_directory, args.executable_sub_path)))
+if not str(content_directory).startswith(str(input_directory)):
+    raise ValueError("Content directory is outside the allowed directory")
 if not str(executable_path).startswith(str(content_directory)):
     raise ValueError("Executable path is outside the allowed directory")
 


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/10](https://github.com/ElProConLag/Ryujinx/security/code-scanning/10)

To fix the problem, we need to ensure that the paths constructed from user input are validated to be within a safe root directory. This can be achieved by normalizing the paths and checking that they start with the expected base path. Specifically, we will:
1. Normalize the `input_directory` and `content_directory` paths.
2. Ensure that the normalized `content_directory` starts with the normalized `input_directory`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
