### PR TITLE
Fix code scanning alert no. 13: Uncontrolled data used in path expression

### DIFF
--- a/distribution/macos/bundle_fix_up.py
+++ b/distribution/macos/bundle_fix_up.py
@@ -531,10 +531,11 @@ def write_bundle_data(
 
 input_directory: Path = Path(os.path.normpath(args.input_directory))
 content_directory: Path = Path(os.path.normpath(os.path.join(input_directory, "Contents")))
-executable_path: Path = Path(os.path.normpath(os.path.join(content_directory, args.executable_sub_path)))
+executable_sub_path: Path = Path(os.path.normpath(args.executable_sub_path))
+executable_path: Path = Path(os.path.normpath(os.path.join(content_directory, executable_sub_path)))
 if not str(content_directory).startswith(str(input_directory)):
     raise ValueError("Content directory is outside the allowed directory")
-if not str(executable_path).startswith(str(content_directory)):
+if not executable_path.is_relative_to(content_directory):
     raise ValueError("Executable path is outside the allowed directory")
 
 


### PR DESCRIPTION
Fixes [https://github.com/ElProConLag/Ryujinx/security/code-scanning/13](https://github.com/ElProConLag/Ryujinx/security/code-scanning/13)

To fix the problem, we need to ensure that the `executable_sub_path` provided by the user is validated more rigorously. We can achieve this by:
1. Normalizing the path to remove any ".." segments.
2. Ensuring that the resulting path is within the `content_directory`.

We will update the code to include these validation steps before using the `executable_path`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
